### PR TITLE
use MarkupSafe's Markup

### DIFF
--- a/mkdocs_markdown_filter/plugin.py
+++ b/mkdocs_markdown_filter/plugin.py
@@ -11,6 +11,7 @@ from mkdocs.plugins import BasePlugin
 import jinja2
 from jinja2.ext import Extension
 import markdown
+import markupsafe
 
 class MarkdownFilterPlugin(BasePlugin):
 
@@ -26,7 +27,7 @@ class MarkdownFilterPlugin(BasePlugin):
             extensions=self.config['markdown_extensions'],
             extension_configs=self.config['mdx_configs'] or {}
         )
-        return jinja2.Markup(md.convert(text))
+        return markupsafe.Markup(md.convert(text))
 
     def on_env(self, env, config, files):
         self.config = config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-mkdocs==1.0.3
+mkdocs
+MarkupSafe


### PR DESCRIPTION
Jinja2 has recently [removed it's own Markup class in favor to using MarkupSafe's implementation](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0).

Therefore with Jinja2 3.1.0 and newer this plugin fails with:

AttributeError: module 'jinja2' has no attribute 'Markup'

This PR replaces the call to jinja2.Markup() with markupsafe.Markup()