### PR TITLE
Add author email and security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities to <markupsafe.markdown.filter@gmail.com>.

--- a/mkdocs_markupsafe_markdown_filter/__version__.py
+++ b/mkdocs_markupsafe_markdown_filter/__version__.py
@@ -4,4 +4,4 @@ Provides the current version information for the package.
 The version is stored as a string in the 'VERSION' variable, following semantic versioning.
 """
 
-VERSION="0.1.0"
+VERSION="0.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = [
 
 authors = [
   {name = "Byrne Reese", email = "byrne@majordojo.com"},
-  {name = "Natan Organick" }
+  {name = "Natan Organick", email = "markupsafe.markdown.filter@gmail.com" }
 ]
 
 maintainers = [


### PR DESCRIPTION
workaround for bug in the PyPI UI where misleading email link is displayed on the project page